### PR TITLE
在同步各种数据库过程中修复以下问题

### DIFF
--- a/XCode/DataAccessLayer/Common/DbBase.cs
+++ b/XCode/DataAccessLayer/Common/DbBase.cs
@@ -779,7 +779,7 @@ abstract class DbBase : DisposeBase, IDatabase
             //!!! 为SQL格式化数值时，如果字符串是Empty，将不再格式化为null
             //if (String.IsNullOrEmpty(value.ToString()) && isNullable) return "null";
 
-            return "'" + value.ToString().Trim('\0').Replace("'", "''") + "'";
+            return "'" + value.ToString().Replace('\0',' ').Replace("'", "''") + "'";
         }
         else if (type == typeof(DateTime))
         {

--- a/XCode/DataAccessLayer/Database/MySql.cs
+++ b/XCode/DataAccessLayer/Database/MySql.cs
@@ -347,19 +347,19 @@ internal class MySqlMetaData : RemoteDbMetaData
 
     #region 数据类型
 
-    //protected override List<KeyValuePair<Type, Type>> FieldTypeMaps
-    //{
-    //    get
-    //    {
-    //        if (_FieldTypeMaps == null)
-    //        {
-    //            var list = base.FieldTypeMaps;
-    //            if (!list.Any(e => e.Key == typeof(Byte) && e.Value == typeof(Boolean)))
-    //                list.Add(new(typeof(Byte), typeof(Boolean)));
-    //        }
-    //        return base.FieldTypeMaps;
-    //    }
-    //}
+    protected override List<KeyValuePair<Type, Type>> FieldTypeMaps
+    {
+        get
+        {
+            if (_FieldTypeMaps == null)
+            {
+                var list = base.FieldTypeMaps;
+                if (!list.Any(e => e.Key == typeof(Byte) && e.Value == typeof(Boolean)))
+                    list.Add(new(typeof(Byte), typeof(Boolean)));
+            }
+            return base.FieldTypeMaps;
+        }
+    }
 
     /// <summary>数据类型映射</summary>
     private static readonly Dictionary<Type, String[]> _DataTypes = new()
@@ -381,6 +381,7 @@ internal class MySqlMetaData : RemoteDbMetaData
         // mysql中nvarchar会变成utf8字符集的varchar，而不会取数据库的utf8mb4
         { typeof(String), new String[] { "VARCHAR({0})", "LONGTEXT", "TEXT", "CHAR({0})", "NCHAR({0})", "NVARCHAR({0})", "SET", "ENUM", "TINYTEXT", "TEXT", "MEDIUMTEXT" } },
         { typeof(Boolean), new String[] { "TINYINT" } },
+        { typeof(Guid), new String[] { "CHAR(36)" } },
     };
 
     #endregion 数据类型

--- a/XCode/DataAccessLayer/Database/SQLite.cs
+++ b/XCode/DataAccessLayer/Database/SQLite.cs
@@ -531,7 +531,7 @@ internal class SQLiteMetaData : FileDbMetaData
 
     static readonly Regex _reg = new("""
         (?:^|,)\s*(\[\w+\]|\w+)
-        \s+(\w+(?:\(\d+(?:,\s*\d+)?\))?)
+        \s*(\w+(?:\(\d+(?:,\s*\d+)?\))?)
         \s*([^,]*)?
         """,
         RegexOptions.Singleline | RegexOptions.IgnorePatternWhitespace | RegexOptions.Multiline | RegexOptions.IgnoreCase);

--- a/XCode/DataAccessLayer/Model/IModelResolver.cs
+++ b/XCode/DataAccessLayer/Model/IModelResolver.cs
@@ -275,6 +275,13 @@ public class ModelResolver : IModelResolver
             if (f != null) f.Master = true;
         }
 
+        // 去除外键
+        if (table.Columns.Any())
+        {
+            table.Columns.RemoveAll(e => e.RawType.EqualIgnoreCase("KEY","K"));
+        }
+
+
         return table;
     }
 


### PR DESCRIPTION
1、sqlite支持旧版v2生成表结构的支持
2、sqlserver当guid为空值时传参报错
3、sqlserver修复了Nvarchar、varchar的长度问题
4、mysql对guid类型对支持，对应类型为CHAR(36)