### PR TITLE
PostgreSQL 实现 DefaultNameFormat 属性返回 NameFormats.Underline

### DIFF
--- a/XCode/DataAccessLayer/Database/PostgreSQL.cs
+++ b/XCode/DataAccessLayer/Database/PostgreSQL.cs
@@ -202,6 +202,9 @@ internal class PostgreSQL : RemoteDb
     /// <summary>系统数据库名</summary>
     public override String SystemDatabaseName => "postgres";
 
+    /// <inheritdoc/>
+    public override NameFormats DefaultNameFormat => NameFormats.Underline;
+
     /// <summary>字符串相加</summary>
     /// <param name="left"></param>
     /// <param name="right"></param>


### PR DESCRIPTION
在 PostgreSQL 类中增加了 DefaultNameFormat 属性的实现，
该属性返回 NameFormats.Underline。

#38 