### PR TITLE
优化 CheckColumnsChange 方法中的列名处理逻辑

### DIFF
--- a/XCode/DataAccessLayer/MetaData/DbMetaData_Negative.cs
+++ b/XCode/DataAccessLayer/MetaData/DbMetaData_Negative.cs
@@ -201,13 +201,13 @@ internal partial class DbMetaData
     protected virtual String CheckColumnsChange(IDataTable entitytable, IDataTable dbtable, Boolean @readonly, Boolean onlyCreate)
     {
         var sb = new StringBuilder();
-        var etdic = entitytable.Columns.ToDictionary(e => e.ColumnName.ToLower(), e => e, StringComparer.OrdinalIgnoreCase);
+        var etdic = entitytable.Columns.ToDictionary(e => this.FormatName(e), e => e, StringComparer.OrdinalIgnoreCase);
         var dbdic = dbtable.Columns.ToDictionary(e => e.ColumnName.ToLower(), e => e, StringComparer.OrdinalIgnoreCase);
 
         #region 新增列
         foreach (var item in entitytable.Columns)
         {
-            if (!dbdic.ContainsKey(item.ColumnName.ToLower()))
+            if (!dbdic.ContainsKey(this.FormatName(item)))
             {
                 // 非空字段需要重建表
                 if (!item.Nullable)
@@ -237,7 +237,7 @@ internal partial class DbMetaData
         for (var i = dbtable.Columns.Count - 1; i >= 0; i--)
         {
             var item = dbtable.Columns[i];
-            if (!etdic.ContainsKey(item.ColumnName.ToLower()))
+            if (!etdic.ContainsKey(item.ColumnName))
             {
                 if (!String.IsNullOrEmpty(item.Description)) PerformSchema(sb, @readonly || onlyCreate, DDLSchema.DropColumnDescription, item);
                 PerformSchema(sbDelete, @readonly || onlyCreate, DDLSchema.DropColumn, item);
@@ -265,7 +265,7 @@ internal partial class DbMetaData
 
         foreach (var item in entitytable.Columns)
         {
-            if (!dbdic.TryGetValue(item.ColumnName, out var dbf)) continue;
+            if (!dbdic.TryGetValue(this.FormatName(item), out var dbf)) continue;
 
             // 对于修改列，只读或者只创建，都只要sql
             if (IsColumnTypeChanged(item, dbf))


### PR DESCRIPTION
将 entitytable.Columns 的字典键从 ColumnName.ToLower() 改为 this.FormatName(e)。 在检查新增列时，判断条件从 !dbdic.ContainsKey(item.ColumnName.ToLower()) 改为 !dbdic.ContainsKey(this.FormatName(item))。 在删除列的部分，判断条件从 !etdic.ContainsKey(item.ColumnName.ToLower()) 改为 !etdic.ContainsKey(item.ColumnName)。 在遍历 entitytable.Columns 时，判断条件从 !dbdic.TryGetValue(item.ColumnName, out var dbf) 改为 !dbdic.TryGetValue(this.FormatName(item), out var dbf)。

#41 