### PR TITLE
解决了在使用sqlserver数据库的情况下，如果表内容为空时，setvalue报错的问题

### DIFF
--- a/XCode/DataAccessLayer/Database/SqlServer.cs
+++ b/XCode/DataAccessLayer/Database/SqlServer.cs
@@ -549,7 +549,7 @@ internal class SqlServerSession : RemoteDbSession
         return dt;
     }
 
-    private Int32[] GetFields(DbTable dt, DbDataReader dr)
+    private Int32[]? GetFields(DbTable dt, DbDataReader dr)
     {
         // 干掉rowNumber
         var idx = Array.FindIndex(dt.Columns, c => c.EqualIgnoreCase("rowNumber"));
@@ -568,7 +568,7 @@ internal class SqlServerSession : RemoteDbSession
             return fs.ToArray();
         }
 
-        return [];
+        return null;
     }
 
     /// <summary>快速查询单表记录数，稍有偏差</summary>


### PR DESCRIPTION
更改GetFields返回类型为可空Int32[]并返回null

将SqlServerSession中的GetFields方法返回类型由Int32[]改为Int32[]?，当未找到字段时返回null而非空数组。调用方需适配null返回值的处理逻辑。